### PR TITLE
conditionally build docx report

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,6 +2,11 @@ name: Deploy documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      generateDocx:
+        description: 'Generate docx report'
+        required: false
+        type: boolean
   push:
     branches:
       - main
@@ -13,6 +18,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    env:
+      generateDocx: ${{ inputs.generateDocx }}
     steps:
 
       - uses: actions/checkout@v4
@@ -36,10 +43,25 @@ jobs:
         run: |
           poe docs
 
+      - name: Generate docx report
+        if: env.generateDocx == 'true'
+        run: |
+          sudo apt-get install -y pandoc
+          sphinx-build -W -b singlehtml docs build/singlehtml
+          cd build/singlehtml && pandoc -s index.html -o ../bmds-user-guide.docx
+
       - name: Upload Pages
         uses: actions/upload-pages-artifact@v3
         with:
           path: build/html/
+
+      - name: Upload Docx
+        if: env.generateDocx == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docx
+          path: build/*.docx
+          retention-days: 14
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
Add new option to github actions to conditionally build a docx file of the user's guide.  If checked, an artifact can be downloaded with a docx file.

![image](https://github.com/user-attachments/assets/e1ad1a12-d354-4080-9e98-3d9a8f26c625)

If checked, a word doc is available for download:
![image](https://github.com/user-attachments/assets/61ee5135-f1e4-4e94-b895-18b80fdda521)


